### PR TITLE
Add Flutter CI workflow with web build artifact

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,26 @@
+name: flutter-ci
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter --version
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test --coverage
+      - run: flutter config --enable-web
+      - run: flutter build web
+      - uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: build/web

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## CI
+
+This project uses a GitHub Actions workflow defined in `.github/workflows/flutter.yml`.
+On pushes and pull requests to the `main` branch the workflow runs:
+
+- `flutter pub get`
+- `flutter analyze`
+- `flutter test --coverage`
+- `flutter build web`
+
+The resulting `build/web` directory is uploaded as a job artifact for easy preview.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running Flutter analyze, tests, and web build with artifact
- document CI workflow in README

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17863f0408320864f87946fe6b29b