### PR TITLE
Add GoRouter and about page

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
 import 'core/design_system/theme.dart';
-import 'features/home/presentation/home_page.dart';
+import 'core/router/app_router.dart';
 
 class App extends StatelessWidget {
-  const App({super.key});
+  App({super.key});
+
+  final _appRouter = AppRouter();
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Rehearsal',
       theme: buildAppTheme(),
-      home: const HomePage(),
+      routerConfig: _appRouter.router,
     );
   }
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,0 +1,20 @@
+import 'package:go_router/go_router.dart';
+import 'package:rehearsal_app/features/about/presentation/about_page.dart';
+import 'package:rehearsal_app/features/home/presentation/home_page.dart';
+
+class AppRouter {
+  AppRouter();
+
+  final GoRouter router = GoRouter(
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const HomePage(),
+      ),
+      GoRoute(
+        path: '/about',
+        builder: (context, state) => const AboutPage(),
+      ),
+    ],
+  );
+}

--- a/lib/features/about/presentation/about_page.dart
+++ b/lib/features/about/presentation/about_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AboutPage extends StatelessWidget {
+  const AboutPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(title: Text('О приложении')),
+      body: Center(child: Text('Rehearsal App v0.1')),
+    );
+  }
+}

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -7,8 +8,18 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Rehearsal App')),
-      body: const Center(
-        child: Text('Добро пожаловать! Это стартовый экран.'),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Добро пожаловать! Это стартовый экран.'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => context.go('/about'),
+              child: const Text('О приложении'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,4 @@
 import 'package:flutter/material.dart';
 import 'app.dart';
 
-void main() => runApp(const App());
+void main() => runApp(App());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^14.2.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,11 +2,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:rehearsal_app/app.dart';
 
 void main() {
-  testWidgets('shows welcome text', (WidgetTester tester) async {
-    await tester.pumpWidget(const App());
+  testWidgets('shows welcome text and about button', (WidgetTester tester) async {
+    await tester.pumpWidget(App());
 
     expect(
       find.text('Добро пожаловать! Это стартовый экран.'),
+      findsOneWidget,
+    );
+
+    expect(
+      find.text('О приложении'),
       findsOneWidget,
     );
   });


### PR DESCRIPTION
## Summary
- integrate go_router and configure AppRouter
- add AboutPage feature and navigate via button on HomePage
- update tests for new button

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b179b05d348320b5a7bef1a575b125