### PR TITLE
fix: adjust AboutPage const usage

### DIFF
--- a/lib/features/about/presentation/about_page.dart
+++ b/lib/features/about/presentation/about_page.dart
@@ -5,9 +5,9 @@ class AboutPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: AppBar(title: Text('О приложении')),
-      body: Center(child: Text('Rehearsal App v0.1')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('О приложении')),
+      body: const Center(child: Text('Rehearsal App v0.1')),
     );
   }
 }


### PR DESCRIPTION
## Summary
- remove const from AboutPage Scaffold and add const to Text widgets
- remove placeholder screenshot asset

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17baa6f088320a6d5f7e1c056bd79