### PR TITLE
fix(db): use wasm database on web

### DIFF
--- a/lib/core/db/app_database.dart
+++ b/lib/core/db/app_database.dart
@@ -27,11 +27,14 @@ class AppDatabase extends _$AppDatabase {
 
 QueryExecutor _openConnection() {
   if (kIsWeb) {
-    return wasm.WasmDatabase.open(
-      databaseName: 'rehearsal',
-      sqlite3Uri: Uri.parse('sqlite3.wasm'),
-      driftWorkerUri: Uri.parse('drift_worker.js'),
-    );
+    return LazyDatabase(() async {
+      final db = await wasm.WasmDatabase.open(
+        databaseName: 'rehearsal',
+        sqlite3Uri: Uri.parse('sqlite3.wasm'),
+        driftWorkerUri: Uri.parse('drift_worker.js'),
+      );
+      return db;
+    });
   } else {
     return LazyDatabase(() async {
       final dir = (Platform.isIOS || Platform.isMacOS)


### PR DESCRIPTION
## Summary
- use wasm `LazyDatabase` for web to return `QueryExecutor`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*
- `flutter build web` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b1d802ab548320b3f75ae9f6f61b67