### PR TITLE
Fix wasm database executor for web drift

### DIFF
--- a/lib/core/db/app_database.dart
+++ b/lib/core/db/app_database.dart
@@ -28,12 +28,17 @@ class AppDatabase extends _$AppDatabase {
 QueryExecutor _openConnection() {
   if (kIsWeb) {
     return LazyDatabase(() async {
-      final db = await wasm.WasmDatabase.open(
+      final result = await wasm.WasmDatabase.open(
         databaseName: 'rehearsal',
         sqlite3Uri: Uri.parse('sqlite3.wasm'),
         driftWorkerUri: Uri.parse('drift_worker.js'),
       );
-      return db;
+
+      if (result is QueryExecutor) {
+        return result;
+      } else {
+        return (result as wasm.WasmDatabaseResult).database;
+      }
     });
   } else {
     return LazyDatabase(() async {


### PR DESCRIPTION
## Summary
- return a `QueryExecutor` when opening the web database by extracting the executor from `WasmDatabaseResult`
- ensure WASM assets are declared in `pubspec.yaml`

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` (fails: command not found)
- `flutter analyze` (fails: command not found)
- `flutter test --coverage` (fails: command not found)
- `flutter build web` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b1dd3513648320b220cb08a4f89e73