### PR TITLE
refactor: isolate database connections for web and io

### DIFF
--- a/lib/core/db/app_database.dart
+++ b/lib/core/db/app_database.dart
@@ -1,10 +1,6 @@
-import 'dart:io' show File, Platform;
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
-import 'package:drift/web.dart';
+
+import 'connection.dart';
 
 part 'app_database.g.dart';
 
@@ -16,26 +12,11 @@ class Users extends Table {
 
 @DriftDatabase(tables: [Users])
 class AppDatabase extends _$AppDatabase {
-  AppDatabase() : super(_openConnection());
+  AppDatabase() : super(openConnection());
 
   @override
   int get schemaVersion => 1;
 
   Future<int> insertUser(UsersCompanion entry) => into(users).insert(entry);
   Future<List<User>> getAllUsers() => select(users).get();
-}
-
-QueryExecutor _openConnection() {
-  if (kIsWeb) {
-    // Temporary hotfix for CI: use WebDatabase to avoid js_interop types on VM tests.
-    return WebDatabase('rehearsal');
-  } else {
-    return LazyDatabase(() async {
-      final dir = (Platform.isIOS || Platform.isMacOS)
-          ? await getLibraryDirectory()
-          : await getApplicationSupportDirectory();
-      final file = File(p.join(dir.path, 'app.sqlite'));
-      return NativeDatabase(file);
-    });
-  }
 }

--- a/lib/core/db/connection.dart
+++ b/lib/core/db/connection.dart
@@ -1,0 +1,2 @@
+export 'connection_io.dart'
+    if (dart.library.js_interop) 'connection_web.dart';

--- a/lib/core/db/connection_io.dart
+++ b/lib/core/db/connection_io.dart
@@ -1,0 +1,16 @@
+import 'dart:io' show File, Platform;
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+QueryExecutor openConnection() {
+  return LazyDatabase(() async {
+    final dir = (Platform.isIOS || Platform.isMacOS)
+        ? await getLibraryDirectory()
+        : await getApplicationSupportDirectory();
+    final file = File(p.join(dir.path, 'app.sqlite'));
+    return NativeDatabase(file);
+  });
+}

--- a/lib/core/db/connection_web.dart
+++ b/lib/core/db/connection_web.dart
@@ -1,0 +1,6 @@
+import 'package:drift/drift.dart';
+import 'package:drift/web.dart';
+
+QueryExecutor openConnection() {
+  return WebDatabase('rehearsal');
+}


### PR DESCRIPTION
## Summary
- remove direct drift/native and drift/web imports from `AppDatabase`
- add dedicated connection files for IO and web and conditionally export
- initialize `AppDatabase` using `openConnection`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*
- `flutter build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e32cb1ec832091a00afa5c815799