### PR TITLE
feat(domain): add CheckConflicts usecase skeleton

### DIFF
--- a/lib/domain/repositories/availability_repository.dart
+++ b/lib/domain/repositories/availability_repository.dart
@@ -1,0 +1,1 @@
+abstract class AvailabilityRepository {}

--- a/lib/domain/repositories/rehearsals_repository.dart
+++ b/lib/domain/repositories/rehearsals_repository.dart
@@ -1,0 +1,1 @@
+abstract class RehearsalsRepository {}

--- a/lib/domain/usecases/check_conflicts.dart
+++ b/lib/domain/usecases/check_conflicts.dart
@@ -1,0 +1,43 @@
+import 'package:rehearsal_app/core/db/app_database.dart';
+
+import '../repositories/availability_repository.dart';
+import '../repositories/rehearsals_repository.dart';
+
+/// Checks conflicts between a rehearsal and attendee schedules.
+///
+/// Uses UTC intervals [startUtc, endUtc). Algorithm is described in ADR-0008.
+class CheckConflicts {
+  CheckConflicts({
+    required this.rehearsalsRepository,
+    required this.availabilityRepository,
+  });
+
+  final RehearsalsRepository rehearsalsRepository;
+  final AvailabilityRepository availabilityRepository;
+
+  /// Returns a list of detected conflicts.
+  ///
+  /// The current placeholder implementation returns an empty list.
+  Future<List<Conflict>> call({
+    required Rehearsal rehearsal,
+    required List<User> attendees,
+  }) async {
+    return [];
+  }
+}
+
+/// Types of conflicts detected for an attendee.
+enum ConflictType { busy, partial, overlap }
+
+/// Describes a scheduling conflict for a user.
+class Conflict {
+  const Conflict({
+    required this.userId,
+    required this.type,
+    this.details,
+  });
+
+  final String userId;
+  final ConflictType type;
+  final String? details;
+}

--- a/test/domain/usecases/check_conflicts_test.dart
+++ b/test/domain/usecases/check_conflicts_test.dart
@@ -1,0 +1,38 @@
+import 'package:test/test.dart';
+import 'package:rehearsal_app/core/db/app_database.dart';
+import 'package:rehearsal_app/domain/repositories/availability_repository.dart';
+import 'package:rehearsal_app/domain/repositories/rehearsals_repository.dart';
+import 'package:rehearsal_app/domain/usecases/check_conflicts.dart';
+
+void main() {
+  test('returns empty list', () async {
+    final usecase = CheckConflicts(
+      rehearsalsRepository: _FakeRehearsalsRepository(),
+      availabilityRepository: _FakeAvailabilityRepository(),
+    );
+    final rehearsal = Rehearsal(
+      id: 'r1',
+      createdAtUtc: 0,
+      updatedAtUtc: 0,
+      lastWriter: 'system',
+      startsAtUtc: 0,
+      endsAtUtc: 1,
+    );
+    final attendee = User(
+      id: 'u1',
+      createdAtUtc: 0,
+      updatedAtUtc: 0,
+      lastWriter: 'system',
+      tz: 'UTC',
+    );
+    final result = await usecase(
+      rehearsal: rehearsal,
+      attendees: [attendee],
+    );
+    expect(result, isEmpty);
+  });
+}
+
+class _FakeRehearsalsRepository implements RehearsalsRepository {}
+
+class _FakeAvailabilityRepository implements AvailabilityRepository {}


### PR DESCRIPTION
## Summary
- scaffold CheckConflicts use case with conflict types
- add repositories placeholders
- add unit test verifying empty result

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a0ae3d3c8320962bdc3a5d4dabfe