### PR TITLE
Add local Drift repositories and smoke tests

### DIFF
--- a/lib/data/repositories/local_availability_repository.dart
+++ b/lib/data/repositories/local_availability_repository.dart
@@ -1,0 +1,79 @@
+import 'package:drift/drift.dart';
+import 'package:rehearsal_app/core/db/app_database.dart';
+import 'package:rehearsal_app/domain/repositories/availability_repository.dart';
+
+class LocalAvailabilityRepository implements AvailabilityRepository {
+  LocalAvailabilityRepository(this.db);
+  final AppDatabase db;
+
+  @override
+  Future<Availability?> getForUserOnDateUtc({
+    required String userId,
+    required int dateUtc00,
+  }) {
+    return (db.select(db.availabilities)
+          ..where((t) => t.userId.equals(userId) & t.dateUtc.equals(dateUtc00))
+          ..where((t) => t.deletedAtUtc.isNull()))
+        .getSingleOrNull();
+  }
+
+  @override
+  Future<List<Availability>> listForUserRange({
+    required String userId,
+    required int fromDateUtc00,
+    required int toDateUtc00,
+  }) {
+    return (db.select(db.availabilities)
+          ..where((t) =>
+              t.userId.equals(userId) &
+              t.dateUtc.isBiggerOrEqualValue(fromDateUtc00) &
+              t.dateUtc.isSmallerThanValue(toDateUtc00))
+          ..where((t) => t.deletedAtUtc.isNull())
+          ..orderBy([(t) => OrderingTerm.asc(t.dateUtc)]))
+        .get();
+  }
+
+  @override
+  Future<void> upsertForUserOnDateUtc({
+    required String userId,
+    required int dateUtc00,
+    required String status,
+    String? intervalsJson,
+    String? note,
+    String lastWriter = 'device:local',
+  }) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    final existing = await getForUserOnDateUtc(
+      userId: userId,
+      dateUtc00: dateUtc00,
+    );
+
+    if (existing == null) {
+      await db.into(db.availabilities).insert(
+            AvailabilitiesCompanion.insert(
+              id: '${userId}_$dateUtc00',
+              userId: userId,
+              dateUtc: dateUtc00,
+              status: status,
+              intervalsJson: Value(intervalsJson),
+              note: Value(note),
+              createdAtUtc: now,
+              updatedAtUtc: now,
+              lastWriter: lastWriter,
+            ),
+          );
+    } else {
+      await (db.update(db.availabilities)
+            ..where((t) => t.id.equals(existing.id)))
+          .write(
+        AvailabilitiesCompanion(
+          status: Value(status),
+          intervalsJson: Value(intervalsJson),
+          note: Value(note),
+          updatedAtUtc: Value(now),
+          lastWriter: Value(lastWriter),
+        ),
+      );
+    }
+  }
+}

--- a/lib/data/repositories/local_rehearsals_repository.dart
+++ b/lib/data/repositories/local_rehearsals_repository.dart
@@ -1,0 +1,103 @@
+import 'package:drift/drift.dart';
+import 'package:rehearsal_app/core/db/app_database.dart';
+import 'package:rehearsal_app/domain/repositories/rehearsals_repository.dart';
+
+class LocalRehearsalsRepository implements RehearsalsRepository {
+  LocalRehearsalsRepository(this.db);
+  final AppDatabase db;
+
+  @override
+  Future<Rehearsal> create({
+    required String id,
+    String? troupeId,
+    required int startsAtUtc,
+    required int endsAtUtc,
+    String? place,
+    String? note,
+    String lastWriter = 'device:local',
+  }) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    await db.into(db.rehearsals).insert(
+          RehearsalsCompanion.insert(
+            id: id,
+            troupeId: Value(troupeId),
+            startsAtUtc: startsAtUtc,
+            endsAtUtc: endsAtUtc,
+            place: Value(place),
+            note: Value(note),
+            createdAtUtc: now,
+            updatedAtUtc: now,
+            lastWriter: lastWriter,
+          ),
+        );
+    return (await getById(id))!;
+  }
+
+  @override
+  Future<Rehearsal?> getById(String id) {
+    return (db.select(db.rehearsals)
+          ..where((t) => t.id.equals(id))
+          ..where((t) => t.deletedAtUtc.isNull()))
+        .getSingleOrNull();
+  }
+
+  @override
+  Future<List<Rehearsal>> listForUserOnDateUtc({
+    required String userId,
+    required int dateUtc00,
+  }) async {
+    final msPerDay = 86400000;
+    final dayEnd = dateUtc00 + msPerDay;
+
+    final joins = await (db.select(db.rehearsalAttendees).join([
+      innerJoin(
+        db.rehearsals,
+        db.rehearsals.id.equalsExp(db.rehearsalAttendees.rehearsalId),
+      ),
+    ])
+          ..where(db.rehearsalAttendees.userId.equals(userId))
+          ..where(db.rehearsalAttendees.deletedAtUtc.isNull())
+          ..where(db.rehearsals.deletedAtUtc.isNull())
+          ..where(db.rehearsals.startsAtUtc.isBiggerOrEqualValue(dateUtc00))
+          ..where(db.rehearsals.startsAtUtc.isSmallerThanValue(dayEnd))
+          ..orderBy([OrderingTerm.asc(db.rehearsals.startsAtUtc)]))
+        .get();
+
+    return joins.map((row) => row.readTable(db.rehearsals)).toList();
+  }
+
+  @override
+  Future<void> update({
+    required String id,
+    int? startsAtUtc,
+    int? endsAtUtc,
+    String? place,
+    String? note,
+    String lastWriter = 'device:local',
+  }) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    await (db.update(db.rehearsals)..where((t) => t.id.equals(id))).write(
+      RehearsalsCompanion(
+        startsAtUtc:
+            startsAtUtc != null ? Value(startsAtUtc) : const Value.absent(),
+        endsAtUtc: endsAtUtc != null ? Value(endsAtUtc) : const Value.absent(),
+        place: place != null ? Value(place) : const Value.absent(),
+        note: note != null ? Value(note) : const Value.absent(),
+        updatedAtUtc: Value(now),
+        lastWriter: Value(lastWriter),
+      ),
+    );
+  }
+
+  @override
+  Future<void> softDelete(String id, {String lastWriter = 'device:local'}) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    await (db.update(db.rehearsals)..where((t) => t.id.equals(id))).write(
+      RehearsalsCompanion(
+        deletedAtUtc: Value(now),
+        updatedAtUtc: Value(now),
+        lastWriter: Value(lastWriter),
+      ),
+    );
+  }
+}

--- a/lib/data/repositories/local_users_repository.dart
+++ b/lib/data/repositories/local_users_repository.dart
@@ -1,0 +1,79 @@
+import 'package:drift/drift.dart';
+import 'package:rehearsal_app/core/db/app_database.dart';
+import 'package:rehearsal_app/domain/repositories/users_repository.dart';
+
+class LocalUsersRepository implements UsersRepository {
+  LocalUsersRepository(this.db);
+  final AppDatabase db;
+
+  @override
+  Future<User> create({
+    required String id,
+    String? name,
+    String? avatarUrl,
+    required String tz,
+    String lastWriter = 'device:local',
+  }) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    await db.into(db.users).insert(
+          UsersCompanion.insert(
+            id: id,
+            name: Value(name),
+            avatarUrl: Value(avatarUrl),
+            tz: tz,
+            createdAtUtc: now,
+            updatedAtUtc: now,
+            lastWriter: lastWriter,
+          ),
+        );
+    return (await getById(id))!;
+  }
+
+  @override
+  Future<User?> getById(String id) {
+    return (db.select(db.users)
+          ..where((t) => t.id.equals(id))
+          ..where((t) => t.deletedAtUtc.isNull()))
+        .getSingleOrNull();
+  }
+
+  @override
+  Future<List<User>> list() {
+    return (db.select(db.users)
+          ..where((t) => t.deletedAtUtc.isNull())
+          ..orderBy([(t) => OrderingTerm.asc(t.name)]))
+        .get();
+  }
+
+  @override
+  Future<void> update({
+    required String id,
+    String? name,
+    String? avatarUrl,
+    String? tz,
+    String lastWriter = 'device:local',
+  }) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    await (db.update(db.users)..where((t) => t.id.equals(id))).write(
+      UsersCompanion(
+        name: name != null ? Value(name) : const Value.absent(),
+        avatarUrl: avatarUrl != null ? Value(avatarUrl) : const Value.absent(),
+        tz: tz != null ? Value(tz) : const Value.absent(),
+        updatedAtUtc: Value(now),
+        lastWriter: Value(lastWriter),
+      ),
+    );
+  }
+
+  @override
+  Future<void> softDelete(String id, {String lastWriter = 'device:local'}) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    await (db.update(db.users)..where((t) => t.id.equals(id))).write(
+      UsersCompanion(
+        deletedAtUtc: Value(now),
+        updatedAtUtc: Value(now),
+        lastWriter: Value(lastWriter),
+      ),
+    );
+  }
+}

--- a/lib/domain/repositories/availability_repository.dart
+++ b/lib/domain/repositories/availability_repository.dart
@@ -1,9 +1,23 @@
 import 'package:rehearsal_app/core/db/app_database.dart';
 
 abstract class AvailabilityRepository {
-  /// Возвращает Availability пользователя на дату (00:00 UTC этого дня), либо null
   Future<Availability?> getForUserOnDateUtc({
     required String userId,
+    required int dateUtc00, // 00:00 UTC millis for the date
+  });
+
+  Future<void> upsertForUserOnDateUtc({
+    required String userId,
     required int dateUtc00,
+    required String status, // 'free' | 'busy' | 'partial'
+    String? intervalsJson, // JSON массив интервалов
+    String? note,
+    String lastWriter = 'device:local',
+  });
+
+  Future<List<Availability>> listForUserRange({
+    required String userId,
+    required int fromDateUtc00,
+    required int toDateUtc00, // exclusive
   });
 }

--- a/lib/domain/repositories/rehearsals_repository.dart
+++ b/lib/domain/repositories/rehearsals_repository.dart
@@ -1,9 +1,31 @@
 import 'package:rehearsal_app/core/db/app_database.dart';
 
 abstract class RehearsalsRepository {
-  /// Возвращает репетиции пользователя за день [dateUtc00, dateUtc00+86400000)
+  Future<Rehearsal> create({
+    required String id,
+    String? troupeId,
+    required int startsAtUtc,
+    required int endsAtUtc,
+    String? place,
+    String? note,
+    String lastWriter = 'device:local',
+  });
+
+  Future<Rehearsal?> getById(String id);
+
   Future<List<Rehearsal>> listForUserOnDateUtc({
     required String userId,
     required int dateUtc00,
   });
+
+  Future<void> update({
+    required String id,
+    int? startsAtUtc,
+    int? endsAtUtc,
+    String? place,
+    String? note,
+    String lastWriter = 'device:local',
+  });
+
+  Future<void> softDelete(String id, {String lastWriter = 'device:local'});
 }

--- a/lib/domain/repositories/users_repository.dart
+++ b/lib/domain/repositories/users_repository.dart
@@ -1,0 +1,24 @@
+import 'package:rehearsal_app/core/db/app_database.dart';
+
+abstract class UsersRepository {
+  Future<User> create({
+    required String id,
+    String? name,
+    String? avatarUrl,
+    required String tz,
+    String lastWriter = 'device:local',
+  });
+
+  Future<User?> getById(String id);
+  Future<List<User>> list();
+
+  Future<void> update({
+    required String id,
+    String? name,
+    String? avatarUrl,
+    String? tz,
+    String lastWriter = 'device:local',
+  });
+
+  Future<void> softDelete(String id, {String lastWriter = 'device:local'});
+}

--- a/test/data/local_repositories_smoke_test.dart
+++ b/test/data/local_repositories_smoke_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rehearsal_app/core/db/connection_test.dart';
+import 'package:rehearsal_app/core/db/app_database.dart';
+import 'package:rehearsal_app/data/repositories/local_users_repository.dart';
+import 'package:rehearsal_app/data/repositories/local_rehearsals_repository.dart';
+import 'package:rehearsal_app/data/repositories/local_availability_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('local repos: basic CRUD & day list', () async {
+    final db = AppDatabase.forTesting(connection: testConnection());
+    final users = LocalUsersRepository(db);
+    final rehearsals = LocalRehearsalsRepository(db);
+    final availability = LocalAvailabilityRepository(db);
+
+    final user = await users.create(id: 'u1', tz: 'UTC');
+    expect(user.id, 'u1');
+
+    final day = DateTime.utc(2025, 1, 2).millisecondsSinceEpoch;
+    final day00 = day - day % 86400000;
+
+    await availability.upsertForUserOnDateUtc(
+      userId: user.id,
+      dateUtc00: day00,
+      status: 'free',
+    );
+    final av = await availability.getForUserOnDateUtc(
+      userId: user.id,
+      dateUtc00: day00,
+    );
+    expect(av?.status, 'free');
+
+    await rehearsals.create(
+      id: 'r1',
+      startsAtUtc: day00 + 10 * 60 * 60 * 1000,
+      endsAtUtc: day00 + 12 * 60 * 60 * 1000,
+    );
+    await db.into(db.rehearsalAttendees).insert(
+          RehearsalAttendeesCompanion.insert(
+            id: 'a1',
+            rehearsalId: 'r1',
+            userId: user.id,
+            role: 'required',
+            createdAtUtc: day00,
+            updatedAtUtc: day00,
+            lastWriter: 'device:local',
+          ),
+        );
+
+    final list = await rehearsals.listForUserOnDateUtc(
+      userId: user.id,
+      dateUtc00: day00,
+    );
+    expect(list.length, 1);
+
+    await db.close();
+  });
+}


### PR DESCRIPTION
## Summary
- expand domain repository interfaces for availabilities, rehearsals, and users
- implement local Drift-backed repositories with CRUD operations
- add smoke test exercising basic CRUD and day listing

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aab3e9b08320b7ce80c837c7ed16