### PR TITLE
feat: add time utilities with timezone support

### DIFF
--- a/lib/core/utils/time.dart
+++ b/lib/core/utils/time.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+/// Returns the UTC start of the day for [anyLocal].
+///
+/// [anyLocal] is interpreted in the local time zone of the user.
+int dateUtc00(DateTime anyLocal) {
+  final localMidnight = DateTime(anyLocal.year, anyLocal.month, anyLocal.day);
+  return localMidnight.toUtc().millisecondsSinceEpoch;
+}
+
+/// Converts a local interval within [dayLocal] to UTC milliseconds.
+({int startUtc, int endUtc}) toUtcInterval(
+  DateTime dayLocal,
+  TimeOfDay startLocal,
+  TimeOfDay endLocal,
+  String tzName,
+) {
+  final location = tz.getLocation(tzName);
+  final start = tz.TZDateTime(
+    location,
+    dayLocal.year,
+    dayLocal.month,
+    dayLocal.day,
+    startLocal.hour,
+    startLocal.minute,
+  );
+  final end = tz.TZDateTime(
+    location,
+    dayLocal.year,
+    dayLocal.month,
+    dayLocal.day,
+    endLocal.hour,
+    endLocal.minute,
+  );
+  return (startUtc: start.millisecondsSinceEpoch, endUtc: end.millisecondsSinceEpoch);
+}
+
+/// Converts a UTC interval to local [TimeOfDay] values in [tzName].
+({TimeOfDay startLocal, TimeOfDay endLocal}) fromUtcInterval(
+  int startUtc,
+  int endUtc,
+  String tzName,
+) {
+  final location = tz.getLocation(tzName);
+  final start = tz.TZDateTime.fromMillisecondsSinceEpoch(location, startUtc);
+  final end = tz.TZDateTime.fromMillisecondsSinceEpoch(location, endUtc);
+  return (
+    startLocal: TimeOfDay(hour: start.hour, minute: start.minute),
+    endLocal: TimeOfDay(hour: end.hour, minute: end.minute),
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   sqlite3: 2.9.0
   path: ^1.9.0
   path_provider: ^2.1.3
+  timezone: ^0.9.2
 
 dev_dependencies:
   flutter_test:

--- a/test/core/utils/time_utils_test.dart
+++ b/test/core/utils/time_utils_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rehearsal_app/core/utils/time.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+void main() {
+  setUpAll(() {
+    tz.initializeTimeZones();
+  });
+
+  test('dateUtc00 returns start of the day in UTC', () {
+    final date = DateTime(2024, 3, 15, 12, 34);
+    final expected = DateTime(date.year, date.month, date.day).toUtc().millisecondsSinceEpoch;
+    expect(dateUtc00(date), expected);
+  });
+
+  test('toUtcInterval and fromUtcInterval handle DST start in Jerusalem', () {
+    const tzName = 'Asia/Jerusalem';
+    final day = DateTime(2024, 3, 29); // DST starts on this day at 02:00
+    final startLocal = const TimeOfDay(hour: 1, minute: 30);
+    final endLocal = const TimeOfDay(hour: 3, minute: 30);
+
+    final interval = toUtcInterval(day, startLocal, endLocal, tzName);
+
+    final location = tz.getLocation(tzName);
+    final expectedStart = tz.TZDateTime(location, day.year, day.month, day.day, 1, 30);
+    final expectedEnd = tz.TZDateTime(location, day.year, day.month, day.day, 3, 30);
+
+    expect(interval.startUtc, expectedStart.millisecondsSinceEpoch);
+    expect(interval.endUtc, expectedEnd.millisecondsSinceEpoch);
+
+    final roundTrip = fromUtcInterval(interval.startUtc, interval.endUtc, tzName);
+    expect(roundTrip.startLocal, startLocal);
+    expect(roundTrip.endLocal, endLocal);
+  });
+
+  test('toUtcInterval and fromUtcInterval handle DST end in Jerusalem', () {
+    const tzName = 'Asia/Jerusalem';
+    final day = DateTime(2024, 10, 27); // DST ends on this day at 02:00
+    final startLocal = const TimeOfDay(hour: 0, minute: 30);
+    final endLocal = const TimeOfDay(hour: 2, minute: 30);
+
+    final interval = toUtcInterval(day, startLocal, endLocal, tzName);
+
+    final location = tz.getLocation(tzName);
+    final expectedStart = tz.TZDateTime(location, day.year, day.month, day.day, 0, 30);
+    final expectedEnd = tz.TZDateTime(location, day.year, day.month, day.day, 2, 30);
+
+    expect(interval.startUtc, expectedStart.millisecondsSinceEpoch);
+    expect(interval.endUtc, expectedEnd.millisecondsSinceEpoch);
+
+    final roundTrip = fromUtcInterval(interval.startUtc, interval.endUtc, tzName);
+    expect(roundTrip.startLocal, startLocal);
+    expect(roundTrip.endLocal, endLocal);
+  });
+}


### PR DESCRIPTION
## Summary
- add timezone-based helpers to convert dates and intervals
- cover time utilities with DST-focused tests
- include timezone dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2af033bc08320802e6152a0e4eef1