### PR TITLE
feat(calendar): add basic calendar page

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:go_router/go_router.dart';
 import 'package:rehearsal_app/features/about/presentation/about_page.dart';
 import 'package:rehearsal_app/features/home/presentation/home_page.dart';
+import 'package:rehearsal_app/features/calendar/presentation/calendar_page.dart';
 
 class AppRouter {
   AppRouter();
@@ -14,6 +15,10 @@ class AppRouter {
       GoRoute(
         path: '/about',
         builder: (context, state) => const AboutPage(),
+      ),
+      GoRoute(
+        path: '/calendar',
+        builder: (context, state) => const CalendarPage(),
       ),
     ],
   );

--- a/lib/features/calendar/presentation/calendar_page.dart
+++ b/lib/features/calendar/presentation/calendar_page.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import 'day_sheet.dart';
+import 'month_view.dart';
+import 'week_view.dart';
+
+/// Main calendar page with Month/Week tabs.
+class CalendarPage extends StatefulWidget {
+  const CalendarPage({super.key});
+
+  @override
+  State<CalendarPage> createState() => _CalendarPageState();
+}
+
+class _CalendarPageState extends State<CalendarPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  DateTime _anchor = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _openDay(DateTime date) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => DaySheet(date: date),
+    );
+  }
+
+  void _next() {
+    setState(() {
+      if (_tabController.index == 0) {
+        _anchor = DateTime(_anchor.year, _anchor.month + 1, 1);
+      } else {
+        _anchor = _anchor.add(const Duration(days: 7));
+      }
+    });
+  }
+
+  void _prev() {
+    setState(() {
+      if (_tabController.index == 0) {
+        _anchor = DateTime(_anchor.year, _anchor.month - 1, 1);
+      } else {
+        _anchor = _anchor.subtract(const Duration(days: 7));
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Calendar'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Month'),
+            Tab(text: 'Week'),
+          ],
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.chevron_left),
+            onPressed: _prev,
+          ),
+          IconButton(
+            icon: const Icon(Icons.chevron_right),
+            onPressed: _next,
+          ),
+        ],
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          MonthView(
+            anchor: _anchor,
+            onDaySelected: _openDay,
+          ),
+          WeekView(
+            anchor: _anchor,
+            onDaySelected: _openDay,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/calendar/presentation/day_cell.dart
+++ b/lib/features/calendar/presentation/day_cell.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// A simple widget showing a day number.
+class DayCell extends StatelessWidget {
+  const DayCell({super.key, required this.date, this.onTap});
+
+  final DateTime date;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.grey.shade300),
+        ),
+        alignment: Alignment.center,
+        child: Text('${date.day}'),
+      ),
+    );
+  }
+}

--- a/lib/features/calendar/presentation/day_sheet.dart
+++ b/lib/features/calendar/presentation/day_sheet.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+/// Bottom sheet displaying basic information about a day.
+class DaySheet extends StatelessWidget {
+  const DaySheet({super.key, required this.date});
+
+  final DateTime date;
+
+  @override
+  Widget build(BuildContext context) {
+    final formatted = '${date.toLocal()}';
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(formatted, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 12),
+          const Text('Доступность: none'),
+          const SizedBox(height: 8),
+          const Text('Репетиции: 0'),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Изменить доступность'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Новая репетиция'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/calendar/presentation/month_view.dart
+++ b/lib/features/calendar/presentation/month_view.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'day_cell.dart';
+
+/// Displays a 6x7 grid representing a month view.
+class MonthView extends StatelessWidget {
+  const MonthView({super.key, required this.anchor, required this.onDaySelected});
+
+  final DateTime anchor;
+  final ValueChanged<DateTime> onDaySelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final firstOfMonth = DateTime(anchor.year, anchor.month, 1);
+    final startCell = firstOfMonth.subtract(
+      Duration(days: firstOfMonth.weekday % 7),
+    );
+    final days = List.generate(42, (i) => startCell.add(Duration(days: i)));
+
+    return GridView.builder(
+      padding: EdgeInsets.zero,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 7,
+      ),
+      itemCount: days.length,
+      itemBuilder: (context, index) {
+        final day = days[index];
+        return DayCell(
+          date: day,
+          onTap: () => onDaySelected(day),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/calendar/presentation/week_view.dart
+++ b/lib/features/calendar/presentation/week_view.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'day_cell.dart';
+
+/// Displays a 1x7 grid representing a week view.
+class WeekView extends StatelessWidget {
+  const WeekView({super.key, required this.anchor, required this.onDaySelected});
+
+  final DateTime anchor;
+  final ValueChanged<DateTime> onDaySelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final start = anchor.subtract(Duration(days: anchor.weekday % 7));
+    final days = List.generate(7, (i) => start.add(Duration(days: i)));
+
+    return GridView.builder(
+      padding: EdgeInsets.zero,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 7,
+      ),
+      itemCount: days.length,
+      itemBuilder: (context, index) {
+        final day = days[index];
+        return DayCell(
+          date: day,
+          onTap: () => onDaySelected(day),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/calendar/state/calendar_controller.dart
+++ b/lib/features/calendar/state/calendar_controller.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'calendar_state.dart';
+
+/// A minimal controller maintaining an anchor date.
+class CalendarController extends ChangeNotifier {
+  CalendarController();
+
+  CalendarState _state = CalendarState(anchor: DateTime.now());
+  CalendarState get state => _state;
+
+  void nextMonth() {
+    _state = CalendarState(
+        anchor: DateTime(_state.anchor.year, _state.anchor.month + 1, 1));
+    notifyListeners();
+  }
+
+  void previousMonth() {
+    _state = CalendarState(
+        anchor: DateTime(_state.anchor.year, _state.anchor.month - 1, 1));
+    notifyListeners();
+  }
+}

--- a/lib/features/calendar/state/calendar_state.dart
+++ b/lib/features/calendar/state/calendar_state.dart
@@ -1,0 +1,5 @@
+class CalendarState {
+  CalendarState({required this.anchor});
+
+  final DateTime anchor;
+}

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -18,6 +18,11 @@ class HomePage extends StatelessWidget {
               onPressed: () => context.go('/about'),
               child: const Text('О приложении'),
             ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => context.go('/calendar'),
+              child: const Text('Календарь'),
+            ),
           ],
         ),
       ),

--- a/test/features/calendar/presentation/calendar_page_test.dart
+++ b/test/features/calendar/presentation/calendar_page_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rehearsal_app/app.dart';
+
+void main() {
+  testWidgets('calendar page shows tabs', (tester) async {
+    await tester.pumpWidget(App());
+
+    await tester.tap(find.text('Календарь'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Calendar'), findsOneWidget);
+    expect(find.text('Month'), findsOneWidget);
+    expect(find.text('Week'), findsOneWidget);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,5 +14,10 @@ void main() {
       find.text('О приложении'),
       findsOneWidget,
     );
+
+    expect(
+      find.text('Календарь'),
+      findsOneWidget,
+    );
   });
 }


### PR DESCRIPTION
## Summary
- add `/calendar` route with month/week tabs
- show day sheet on tap
- add navigation button from home page

## Testing
- ❌ `flutter analyze` (missing `flutter` command)
- ❌ `flutter test` (missing `flutter` command)


------
https://chatgpt.com/codex/tasks/task_e_68b2ce32c32483209c8d22dfc33a73c4