### PR TITLE
Add CalendarGrid widget with availability indicators

### DIFF
--- a/lib/features/availability/presentation/widgets/calendar_grid.dart
+++ b/lib/features/availability/presentation/widgets/calendar_grid.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/utils/time.dart';
+
+/// Indicates availability for a particular day.
+enum AvailabilityStatus { free, busy, partial }
+
+/// Grid-based calendar widget that shows availability indicators for days.
+class CalendarGrid extends StatelessWidget {
+  const CalendarGrid({
+    super.key,
+    required this.month,
+    required this.byDate,
+    this.onDayTap,
+  });
+
+  /// Local month to display.
+  final DateTime month;
+
+  /// Map from `dateUtc00` to the day's availability status.
+  final Map<int, AvailabilityStatus> byDate;
+
+  /// Called when a day is tapped.
+  final void Function(DateTime day)? onDayTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final firstDay = DateTime(month.year, month.month, 1);
+    final leadingEmpty = firstDay.weekday - 1; // Monday first
+    final daysInMonth = DateTime(month.year, month.month + 1, 0).day;
+    final totalShown = leadingEmpty + daysInMonth;
+    final rows = (totalShown / 7).ceil();
+    final itemCount = rows * 7;
+    final startDay = firstDay.subtract(Duration(days: leadingEmpty));
+
+    return GridView.builder(
+      physics: const NeverScrollableScrollPhysics(),
+      shrinkWrap: true,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 7,
+      ),
+      itemCount: itemCount,
+      itemBuilder: (context, index) {
+        final day = startDay.add(Duration(days: index));
+        final keyBase = dateUtc00(day);
+        final status = byDate[keyBase];
+        final isCurrentMonth = day.month == month.month;
+
+        return GestureDetector(
+          key: ValueKey('day-' + keyBase.toString()),
+          onTap: () => onDayTap?.call(day),
+          child: Container(
+            alignment: Alignment.center,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '${day.day}',
+                  style: TextStyle(
+                    color: isCurrentMonth ? Colors.black : Colors.grey,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                _StatusDot(
+                  key: ValueKey('dot-' + keyBase.toString()),
+                  status: status,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _StatusDot extends StatelessWidget {
+  const _StatusDot({super.key, this.status});
+
+  final AvailabilityStatus? status;
+
+  Color? _color() {
+    switch (status) {
+      case AvailabilityStatus.free:
+        return Colors.green;
+      case AvailabilityStatus.busy:
+        return Colors.red;
+      case AvailabilityStatus.partial:
+        return Colors.yellow;
+      case null:
+        return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color();
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color,
+        border: color == null ? Border.all(color: Colors.grey) : null,
+      ),
+    );
+  }
+}

--- a/test/features/availability/calendar_grid_test.dart
+++ b/test/features/availability/calendar_grid_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rehearsal_app/core/utils/time.dart';
+import 'package:rehearsal_app/features/availability/presentation/widgets/calendar_grid.dart';
+
+void main() {
+  group('CalendarGrid', () {
+    testWidgets('renders month with 31 days', (tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: CalendarGrid(
+          month: DateTime(2024, 1),
+          byDate: {},
+        ),
+      ));
+
+      // 31 days + 4 trailing days = 35 cells
+      expect(find.byType(GestureDetector), findsNWidgets(35));
+      expect(find.text('31'), findsOneWidget);
+    });
+
+    testWidgets('shows status indicators', (tester) async {
+      final dayFree = DateTime(2024, 1, 10);
+      final dayBusy = DateTime(2024, 1, 11);
+      final dayPartial = DateTime(2024, 1, 12);
+      final map = <int, AvailabilityStatus>{
+        dateUtc00(dayFree): AvailabilityStatus.free,
+        dateUtc00(dayBusy): AvailabilityStatus.busy,
+        dateUtc00(dayPartial): AvailabilityStatus.partial,
+      };
+
+      await tester.pumpWidget(MaterialApp(
+        home: CalendarGrid(
+          month: DateTime(2024, 1),
+          byDate: map,
+        ),
+      ));
+
+      BoxDecoration decoration;
+
+      decoration = tester.widget<Container>(
+        find.byKey(ValueKey('dot-${dateUtc00(dayFree)}')),
+      ).decoration! as BoxDecoration;
+      expect(decoration.color, Colors.green);
+
+      decoration = tester.widget<Container>(
+        find.byKey(ValueKey('dot-${dateUtc00(dayBusy)}')),
+      ).decoration! as BoxDecoration;
+      expect(decoration.color, Colors.red);
+
+      decoration = tester.widget<Container>(
+        find.byKey(ValueKey('dot-${dateUtc00(dayPartial)}')),
+      ).decoration! as BoxDecoration;
+      expect(decoration.color, Colors.yellow);
+
+      final dayNone = DateTime(2024, 1, 13);
+      decoration = tester.widget<Container>(
+        find.byKey(ValueKey('dot-${dateUtc00(dayNone)}')),
+      ).decoration! as BoxDecoration;
+      final Border? border = decoration.border as Border?;
+      expect(border?.top.color, Colors.grey);
+    });
+
+    testWidgets('tapping day triggers callback', (tester) async {
+      DateTime? tapped;
+      final day = DateTime(2024, 1, 15);
+
+      await tester.pumpWidget(MaterialApp(
+        home: CalendarGrid(
+          month: DateTime(2024, 1),
+          byDate: const {},
+          onDayTap: (d) => tapped = d,
+        ),
+      ));
+
+      await tester.tap(find.byKey(ValueKey('day-${dateUtc00(day)}')));
+      expect(tapped, day);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement CalendarGrid widget with colored availability dots and day tap callback
- add tests for grid rendering, status indicators, and tap handling

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d037a43c83208ce46c9951c56e74