### PR TITLE
Add basic availability page and router integration

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -2,6 +2,7 @@ import 'package:go_router/go_router.dart';
 import 'package:rehearsal_app/features/about/presentation/about_page.dart';
 import 'package:rehearsal_app/features/home/presentation/home_page.dart';
 import 'package:rehearsal_app/features/calendar/presentation/calendar_page.dart';
+import 'package:rehearsal_app/features/availability/presentation/availability_page.dart';
 
 class AppRouter {
   AppRouter();
@@ -19,6 +20,10 @@ class AppRouter {
       GoRoute(
         path: '/calendar',
         builder: (context, state) => const CalendarPage(),
+      ),
+      GoRoute(
+        path: '/availability',
+        builder: (context, state) => const AvailabilityPage(),
       ),
     ],
   );

--- a/lib/features/availability/presentation/availability_page.dart
+++ b/lib/features/availability/presentation/availability_page.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../controller/availability_provider.dart';
+import 'widgets/calendar_grid.dart' as grid;
+
+class AvailabilityPage extends ConsumerWidget {
+  const AvailabilityPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Trigger loading for the currently visible month and when it changes.
+    ref.listen<DateTime>(
+      availabilityControllerProvider.select((s) => s.visibleMonth),
+      (_, month) {
+        ref.read(availabilityControllerProvider.notifier).loadMonth(month);
+      },
+      fireImmediately: true,
+    );
+
+    final pageState = ref.watch(availabilityControllerProvider);
+    final l10n = AppLocalizations.of(context)!;
+
+    final byDate = pageState.byDate.map(
+      (key, view) => MapEntry(
+        key,
+        grid.AvailabilityStatus.values[view.status.index],
+      ),
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.availability_title)),
+      body: Column(
+        children: [
+          const SizedBox(height: 8),
+          ToggleButtons(
+            isSelected: const [true, false],
+            onPressed: (_) {},
+            children: const [
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Text('Month'),
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Text('Week'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          grid.CalendarGrid(
+            month: pageState.visibleMonth,
+            byDate: byDate,
+            onDayTap: (day) {
+              showModalBottomSheet(
+                context: context,
+                builder: (_) => Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text('Day: $day'),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -23,6 +23,11 @@ class HomePage extends StatelessWidget {
               onPressed: () => context.go('/calendar'),
               child: const Text('Календарь'),
             ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => context.go('/availability'),
+              child: const Text('Availability'),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- create basic AvailabilityPage with calendar grid and placeholder day sheet
- wire up /availability route and add navigation from home screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3069dce488320b1fd24ec75a55b70