### PR TITLE
feat(availability): add DayBottomSheet and E2E widget tests for AvailabilityPage

### DIFF
--- a/lib/features/availability/presentation/availability_page.dart
+++ b/lib/features/availability/presentation/availability_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../controller/availability_provider.dart';
+import 'day_bottom_sheet.dart';
 import 'widgets/calendar_grid.dart' as grid;
 
 class AvailabilityPage extends ConsumerWidget {
@@ -53,13 +54,11 @@ class AvailabilityPage extends ConsumerWidget {
           grid.CalendarGrid(
             month: pageState.visibleMonth,
             byDate: byDate,
-            onDayTap: (day) {
-              showModalBottomSheet(
+            onDayTap: (day) async {
+              await showModalBottomSheet<bool>(
                 context: context,
-                builder: (_) => Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text('Day: $day'),
-                ),
+                isScrollControlled: true,
+                builder: (_) => DayBottomSheet(dayLocal: day),
               );
             },
           ),

--- a/lib/features/availability/presentation/day_bottom_sheet.dart
+++ b/lib/features/availability/presentation/day_bottom_sheet.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+import '../controller/availability_provider.dart';
+import '../controller/availability_state.dart';
+
+class DayBottomSheet extends ConsumerStatefulWidget {
+  const DayBottomSheet({super.key, required this.dayLocal});
+
+  final DateTime dayLocal;
+
+  @override
+  ConsumerState<DayBottomSheet> createState() => _DayBottomSheetState();
+}
+
+class _DayBottomSheetState extends ConsumerState<DayBottomSheet> {
+  AvailabilityStatus _status = AvailabilityStatus.free;
+  final _intervals = <({TimeOfDay start, TimeOfDay end})>[];
+
+  void _addInterval() {
+    if (_intervals.length >= 6) return;
+    setState(() {
+      _intervals.add((
+        start: const TimeOfDay(hour: 10, minute: 0),
+        end: const TimeOfDay(hour: 11, minute: 0),
+      ));
+    });
+  }
+
+  Future<void> _pickStart(int index) async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _intervals[index].start,
+    );
+    if (picked != null) {
+      setState(() {
+        final cur = _intervals[index];
+        _intervals[index] = (start: picked, end: cur.end);
+      });
+    }
+  }
+
+  Future<void> _pickEnd(int index) async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _intervals[index].end,
+    );
+    if (picked != null) {
+      setState(() {
+        final cur = _intervals[index];
+        _intervals[index] = (start: cur.start, end: picked);
+      });
+    }
+  }
+
+  void _removeInterval(int index) {
+    setState(() {
+      _intervals.removeAt(index);
+    });
+  }
+
+  void _showError() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        key: const Key('availability_snackbar_error'),
+        content: const Text('Error'),
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    final controller = ref.read(availabilityControllerProvider.notifier);
+    if (_status == AvailabilityStatus.partial) {
+      if (_intervals.isEmpty) {
+        _showError();
+        return;
+      }
+      await controller.setIntervals(
+        dayLocal: widget.dayLocal,
+        intervalsLocal: _intervals,
+        tz: tz.local.name,
+      );
+    } else {
+      await controller.setStatus(dayLocal: widget.dayLocal, status: _status);
+    }
+    final error = ref.read(availabilityControllerProvider).error;
+    if (error != null) {
+      _showError();
+    } else {
+      Navigator.of(context).pop(true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+        top: 16,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ChoiceChip(
+                key: const Key('status_free'),
+                label: const Text('Free'),
+                selected: _status == AvailabilityStatus.free,
+                onSelected: (_) => setState(() {
+                  _status = AvailabilityStatus.free;
+                }),
+              ),
+              const SizedBox(width: 8),
+              ChoiceChip(
+                key: const Key('status_busy'),
+                label: const Text('Busy'),
+                selected: _status == AvailabilityStatus.busy,
+                onSelected: (_) => setState(() {
+                  _status = AvailabilityStatus.busy;
+                }),
+              ),
+              const SizedBox(width: 8),
+              ChoiceChip(
+                key: const Key('status_partial'),
+                label: const Text('Partial'),
+                selected: _status == AvailabilityStatus.partial,
+                onSelected: (_) => setState(() {
+                  _status = AvailabilityStatus.partial;
+                }),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          if (_status == AvailabilityStatus.partial) ...[
+            ElevatedButton(
+              key: const Key('add_interval'),
+              onPressed: _addInterval,
+              child: const Text('Add interval'),
+            ),
+            const SizedBox(height: 8),
+            for (var i = 0; i < _intervals.length; i++)
+              Row(
+                children: [
+                  TextButton(
+                    key: Key('start_$i'),
+                    onPressed: () => _pickStart(i),
+                    child: Text(_intervals[i].start.format(context)),
+                  ),
+                  TextButton(
+                    key: Key('end_$i'),
+                    onPressed: () => _pickEnd(i),
+                    child: Text(_intervals[i].end.format(context)),
+                  ),
+                  IconButton(
+                    key: Key('remove_$i'),
+                    onPressed: () => _removeInterval(i),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+          ],
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                key: const Key('cancel_btn'),
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                key: const Key('save_btn'),
+                onPressed: _save,
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/test/features/availability/availability_page_test.dart
+++ b/test/features/availability/availability_page_test.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rehearsal_app/core/db/app_database.dart';
+import 'package:rehearsal_app/core/utils/time.dart';
+import 'package:rehearsal_app/domain/repositories/availability_repository.dart';
+import 'package:rehearsal_app/features/availability/controller/availability_provider.dart';
+import 'package:rehearsal_app/features/availability/presentation/availability_page.dart';
+import 'package:rehearsal_app/features/availability/presentation/day_bottom_sheet.dart';
+import 'package:timezone/data/latest.dart' as tzdata;
+
+class _FakeAvailabilityRepo implements AvailabilityRepository {
+  final map = <(String, int), Availability>{};
+
+  @override
+  Future<List<Availability>> listForUserRange({
+    required String userId,
+    required int fromDateUtc00,
+    required int toDateUtc00,
+  }) async {
+    final result = <Availability>[];
+    for (final e in map.entries) {
+      final k = e.key;
+      if (k.$1 == userId && k.$2 >= fromDateUtc00 && k.$2 <= toDateUtc00) {
+        result.add(e.value);
+      }
+    }
+    result.sort((a, b) => a.dateUtc.compareTo(b.dateUtc));
+    return result;
+  }
+
+  @override
+  Future<void> upsertForUserOnDateUtc({
+    required String userId,
+    required int dateUtc00,
+    required String status,
+    String? intervalsJson,
+    String? note,
+    String lastWriter = 'device:local',
+  }) async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    map[(userId, dateUtc00)] = Availability(
+      id: '${userId}_$dateUtc00',
+      createdAtUtc: now,
+      updatedAtUtc: now,
+      deletedAtUtc: null,
+      lastWriter: lastWriter,
+      userId: userId,
+      dateUtc: dateUtc00,
+      status: status,
+      intervalsJson: intervalsJson,
+      note: note,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  setUpAll(() {
+    tzdata.initializeTimeZones();
+  });
+
+  testWidgets('open and save free', (tester) async {
+    final fake = _FakeAvailabilityRepo();
+    final container = ProviderContainer(overrides: [
+      availabilityRepositoryProvider.overrideWithValue(fake),
+      currentUserIdProvider.overrideWithValue('u1'),
+    ]);
+    addTearDown(container.dispose);
+
+    await container.read(availabilityControllerProvider.notifier).loadMonth(DateTime(2024, 1));
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: AvailabilityPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final day = DateTime(2024, 1, 1);
+    await tester.tap(find.byKey(ValueKey('day-${dateUtc00(day)}')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('status_free')));
+    await tester.tap(find.byKey(const Key('save_btn')));
+    await tester.pumpAndSettle();
+
+    final key = dateUtc00(day);
+    final saved = fake.map[('u1', key)]!;
+    expect(saved.status, 'free');
+    expect(saved.intervalsJson, isNull);
+  });
+
+  testWidgets('partial with touching intervals', (tester) async {
+    final fake = _FakeAvailabilityRepo();
+    final container = ProviderContainer(overrides: [
+      availabilityRepositoryProvider.overrideWithValue(fake),
+      currentUserIdProvider.overrideWithValue('u1'),
+    ]);
+    addTearDown(container.dispose);
+
+    await container.read(availabilityControllerProvider.notifier).loadMonth(DateTime(2024, 1));
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: AvailabilityPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final day = DateTime(2024, 1, 2);
+    await tester.tap(find.byKey(ValueKey('day-${dateUtc00(day)}')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('status_partial')));
+    await tester.tap(find.byKey(const Key('add_interval')));
+    await tester.tap(find.byKey(const Key('add_interval')));
+    await tester.pump();
+
+    final state = tester.state(find.byType(DayBottomSheet)) as dynamic;
+    state.setState(() {
+      state._intervals[1] = (
+        start: const TimeOfDay(hour: 11, minute: 0),
+        end: const TimeOfDay(hour: 12, minute: 0),
+      );
+    });
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('save_btn')));
+    await tester.pumpAndSettle();
+
+    final key = dateUtc00(day);
+    final saved = fake.map[('u1', key)]!;
+    expect(saved.status, 'partial');
+    expect(saved.intervalsJson, isNotNull);
+    final parsed = (jsonDecode(saved.intervalsJson!) as List).cast<Map<String, dynamic>>();
+    expect(parsed, hasLength(2));
+    final dayStart = key;
+    final dayEnd = key + const Duration(days: 1).inMilliseconds;
+    for (final m in parsed) {
+      final s = m['startUtc'] as int;
+      final e = m['endUtc'] as int;
+      expect(s >= dayStart && e <= dayEnd, true);
+    }
+  });
+
+  testWidgets('overlapping intervals show error', (tester) async {
+    final fake = _FakeAvailabilityRepo();
+    final container = ProviderContainer(overrides: [
+      availabilityRepositoryProvider.overrideWithValue(fake),
+      currentUserIdProvider.overrideWithValue('u1'),
+    ]);
+    addTearDown(container.dispose);
+
+    await container.read(availabilityControllerProvider.notifier).loadMonth(DateTime(2024, 1));
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: AvailabilityPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final day = DateTime(2024, 1, 3);
+    await tester.tap(find.byKey(ValueKey('day-${dateUtc00(day)}')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('status_partial')));
+    await tester.tap(find.byKey(const Key('add_interval')));
+    await tester.tap(find.byKey(const Key('add_interval')));
+    await tester.tap(find.byKey(const Key('save_btn')));
+    await tester.pump();
+
+    expect(find.byKey(const Key('availability_snackbar_error')), findsOneWidget);
+    final key = dateUtc00(day);
+    expect(fake.map.containsKey(('u1', key)), false);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add DayBottomSheet with status and interval editing
- hook DayBottomSheet into AvailabilityPage
- cover availability flow with widget tests

## Testing
- ⚠️ `flutter analyze` *(command not found)*
- ⚠️ `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b30e1212d08320bb4e4df7489fc1c0