### PR TITLE
Use unified haptics helper in day scroller

### DIFF
--- a/lib/features/dashboard/widgets/day_scroller.dart
+++ b/lib/features/dashboard/widgets/day_scroller.dart
@@ -2,7 +2,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:rehearsal_app/core/ui/haptics.dart';
 
 /// A glassy, horizontally scrollable strip of days with:
 ///  • centered month label (updates as you scroll)
@@ -202,11 +202,8 @@ class _DayScrollerState extends State<DayScroller> {
                         final newDate = _dateForIndex(index);
                         // Fire haptics once per day change
                         if (_selected != newDate) {
-                          if (widget.onHaptic != null) {
-                            widget.onHaptic!.call();
-                          } else {
-                            HapticFeedback.selectionClick();
-                          }
+                          Haptics.selection();
+                          widget.onHaptic?.call();
                         }
                         setState(() => _selected = newDate);
                         widget.onDateChanged?.call(newDate);


### PR DESCRIPTION
## Summary
- replace direct `HapticFeedback.selectionClick` usage with `Haptics.selection`
- wire `onHaptic` callback after the standard selection haptic
- depend on centralized `Haptics` helper instead of `flutter/services`

## Testing
- `dart format lib/features/dashboard/widgets/day_scroller.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59dd11d88832080db75938fa997be