### PR TITLE
feat: add light and dark themes

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'core/design_system/theme.dart';
+import 'package:rehearsal_app/core/design_system/theme.dart';
 import 'core/l10n/locale_provider.dart';
 import 'package:rehearsal_app/l10n/app.dart';
 import 'package:rehearsal_app/l10n/app_localizations.dart';
@@ -17,6 +17,8 @@ class App extends ConsumerWidget {
       locale: ref.watch(localeProvider),
       onGenerateTitle: (context) => context.l10n.appTitle,
       theme: buildAppTheme(),
+      darkTheme: buildAppDarkTheme(),
+      themeMode: ThemeMode.system,
       routerConfig: _appRouter.router,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/lib/core/design_system/app_colors.dart
+++ b/lib/core/design_system/app_colors.dart
@@ -14,6 +14,7 @@ final class AppColors {
   // === NEUTRALS ===
   static const Color black = Color(0xFF0B0B0B);
   static const Color white = Color(0xFFFFFFFF);
+  static const Color darkBase = black;
 
   // === TEXT (\u043f\u043e \u0443\u043c\u043e\u043b\u0447\u0430\u043d\u0438\u044e \u0434\u043b\u044f light) ===
   static final Color textPrimary        = black.withValues(alpha: 0.85);

--- a/lib/core/design_system/theme.dart
+++ b/lib/core/design_system/theme.dart
@@ -1,8 +1,56 @@
 import 'package:flutter/material.dart';
+import 'app_colors.dart';
+import 'app_typography.dart';
+import 'app_spacing.dart';
 
 ThemeData buildAppTheme() {
   return ThemeData(
     useMaterial3: true,
-    colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+    brightness: Brightness.light,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: AppColors.primaryPurple,
+      brightness: Brightness.light,
+    ),
+    textTheme: const TextTheme(
+      displayLarge: AppTypography.displayLarge,
+      bodyLarge: AppTypography.bodyLarge,
+      bodyMedium: AppTypography.bodyMedium,
+      bodySmall: AppTypography.bodySmall,
+    ),
+    scaffoldBackgroundColor: Colors.white,
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        minimumSize: const Size(0, AppSpacing.buttonHeight),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusLG),
+        ),
+      ),
+    ),
+  );
+}
+
+ThemeData buildAppDarkTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: AppColors.primaryPurple,
+      brightness: Brightness.dark,
+    ),
+    textTheme: const TextTheme(
+      displayLarge: AppTypography.displayLarge,
+      bodyLarge: AppTypography.bodyLarge,
+      bodyMedium: AppTypography.bodyMedium,
+      bodySmall: AppTypography.bodySmall,
+    ),
+    scaffoldBackgroundColor: AppColors.darkBase,
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        minimumSize: const Size(0, AppSpacing.buttonHeight),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusLG),
+        ),
+      ),
+    ),
   );
 }


### PR DESCRIPTION
## Summary
- add light and dark themes using design system colors, spacing, and typography
- hook up dark theme and system theme mode in `MaterialApp`
- expose `darkBase` color in palette for dark scaffold background

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c5c18f6483208d3cf75d394f8687