### PR TITLE
refactor(ui): migrate to GlassBackground from design system and format code

### DIFF
--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:rehearsal_app/core/design_system/app_spacing.dart';
 import 'package:rehearsal_app/core/design_system/glass_system.dart' as ds;
 import 'package:rehearsal_app/features/dashboard/widgets/day_scroller.dart';
 
@@ -17,15 +18,18 @@ class _DashboardPageState extends State<DashboardPage> {
       body: ds.GlassBackground(
         child: SafeArea(
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.md,
+            ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // Стеклянная панель с DayScroller — БЕЗ дополнительных обёрток стекла внутри
-                ds.GlassCard(
+                ds.GlassPanel(
                   child: SizedBox(height: 120, child: DayScroller()),
                 ),
-                const SizedBox(height: 16),
+                const SizedBox(height: AppSpacing.lg),
               ],
             ),
           ),

--- a/lib/features/dashboard/widgets/weekly_header.dart
+++ b/lib/features/dashboard/widgets/weekly_header.dart
@@ -27,7 +27,7 @@ class WeeklyHeader extends StatelessWidget {
           DateTime(start.year, start.month, start.day).add(Duration(days: i)),
     );
 
-    return GlassCard(
+    return GlassPanel(
       child: Padding(
         padding: const EdgeInsets.symmetric(
           horizontal: AppSpacing.lg,


### PR DESCRIPTION
## Summary
- migrate DashboardPage to design-system GlassBackground and use GlassPanel
- replace WeeklyHeader glass card with design-system GlassPanel
- switch layout constants to AppSpacing tokens

## Testing
- `dart format lib/features/dashboard/presentation/dashboard_page.dart lib/features/dashboard/widgets/weekly_header.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b723e21f848320a1311629ccf6f0d0