### PR TITLE
feat: add glass chip and use in day sheet

### DIFF
--- a/lib/core/design_system/glass_system.dart
+++ b/lib/core/design_system/glass_system.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'app_colors.dart';
 import 'app_spacing.dart';
+import 'app_typography.dart';
 
 enum GlassStyle { light, dark, accent }
 
@@ -227,6 +228,53 @@ class GlassButton extends StatelessWidget {
       child: DefaultTextStyle.merge(
         style: TextStyle(color: textColor),
         child: child,
+      ),
+    );
+  }
+}
+
+/// Компактный стеклянный чип для выбора опций.
+/// Похож на GlassButton, но меньше и с фиксированным размером.
+class GlassChip extends StatelessWidget {
+  const GlassChip({
+    super.key,
+    required this.label,
+    required this.onTap,
+    this.selected = false,
+  });
+
+  final String label;
+  final VoidCallback onTap;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textColor = selected
+        ? (isDark ? Colors.white : Colors.white.withValues(alpha: 0.95))
+        : (isDark
+            ? Colors.white.withValues(alpha: 0.70)
+            : Colors.black.withValues(alpha: 0.60));
+
+    return SizedBox(
+      height: 32, // Фиксированная высота для чипов
+      child: AppGlass(
+        style: selected ? GlassStyle.accent : GlassStyle.light,
+        size: GlassSize.small,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.xs,
+        ),
+        onTap: onTap,
+        child: Center(
+          child: Text(
+            label,
+            style: AppTypography.label.copyWith(
+              color: textColor,
+              fontSize: 13,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/availability/presentation/day_bottom_sheet.dart
+++ b/lib/features/availability/presentation/day_bottom_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:rehearsal_app/core/design_system/app_spacing.dart';
 import 'package:rehearsal_app/core/design_system/app_typography.dart';
+import 'package:rehearsal_app/core/design_system/glass_system.dart';
 import 'package:rehearsal_app/core/design_system/haptics.dart';
 import 'package:rehearsal_app/l10n/app.dart';
 import 'package:timezone/timezone.dart' as tz;
@@ -124,17 +125,11 @@ class _DayBottomSheetState extends ConsumerState<DayBottomSheet> {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              ChoiceChip(
+              GlassChip(
                 key: const Key('status_free'),
-                label: Text(
-                  context.l10n.availabilityStatusFree,
-                  style: AppTypography.label,
-                ),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppSpacing.radiusMD),
-                ),
+                label: context.l10n.availabilityStatusFree,
                 selected: _status == AvailabilityStatus.free,
-                onSelected: (_) {
+                onTap: () {
                   setState(() {
                     _status = AvailabilityStatus.free;
                   });
@@ -142,17 +137,11 @@ class _DayBottomSheetState extends ConsumerState<DayBottomSheet> {
                 },
               ),
               const SizedBox(width: AppSpacing.sm),
-              ChoiceChip(
+              GlassChip(
                 key: const Key('status_busy'),
-                label: Text(
-                  context.l10n.availabilityStatusBusy,
-                  style: AppTypography.label,
-                ),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppSpacing.radiusMD),
-                ),
+                label: context.l10n.availabilityStatusBusy,
                 selected: _status == AvailabilityStatus.busy,
-                onSelected: (_) {
+                onTap: () {
                   setState(() {
                     _status = AvailabilityStatus.busy;
                   });
@@ -160,17 +149,11 @@ class _DayBottomSheetState extends ConsumerState<DayBottomSheet> {
                 },
               ),
               const SizedBox(width: AppSpacing.sm),
-              ChoiceChip(
+              GlassChip(
                 key: const Key('status_partial'),
-                label: Text(
-                  context.l10n.availabilityStatusPartial,
-                  style: AppTypography.label,
-                ),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppSpacing.radiusMD),
-                ),
+                label: context.l10n.availabilityStatusPartial,
                 selected: _status == AvailabilityStatus.partial,
-                onSelected: (_) {
+                onTap: () {
                   setState(() {
                     _status = AvailabilityStatus.partial;
                   });


### PR DESCRIPTION
## Summary
- add reusable GlassChip component for compact glass-styled options
- use GlassChip for availability status selection in day bottom sheet

## Testing
- `dart format lib/core/design_system/glass_system.dart lib/features/availability/presentation/day_bottom_sheet.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73773c7e88320869ddac91357827f