### PR TITLE
Use GlassChip for availability status selection

### DIFF
--- a/lib/features/availability/presentation/day_bottom_sheet.dart
+++ b/lib/features/availability/presentation/day_bottom_sheet.dart
@@ -125,61 +125,34 @@ class _DayBottomSheetState extends ConsumerState<DayBottomSheet> {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              GlassButton(
+              GlassChip(
                 key: const Key('status_free'),
+                label: context.l10n.availabilityStatusFree,
                 selected: _status == AvailabilityStatus.free,
                 onTap: () {
                   setState(() => _status = AvailabilityStatus.free);
                   Haptics.selection();
                 },
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.md,
-                    vertical: AppSpacing.xs,
-                  ),
-                  child: Text(
-                    context.l10n.availabilityStatusFree,
-                    style: AppTypography.label,
-                  ),
-                ),
               ),
               const SizedBox(width: AppSpacing.sm),
-              GlassButton(
+              GlassChip(
                 key: const Key('status_busy'),
+                label: context.l10n.availabilityStatusBusy,
                 selected: _status == AvailabilityStatus.busy,
                 onTap: () {
                   setState(() => _status = AvailabilityStatus.busy);
                   Haptics.selection();
                 },
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.md,
-                    vertical: AppSpacing.xs,
-                  ),
-                  child: Text(
-                    context.l10n.availabilityStatusBusy,
-                    style: AppTypography.label,
-                  ),
-                ),
               ),
               const SizedBox(width: AppSpacing.sm),
-              GlassButton(
+              GlassChip(
                 key: const Key('status_partial'),
+                label: context.l10n.availabilityStatusPartial,
                 selected: _status == AvailabilityStatus.partial,
                 onTap: () {
                   setState(() => _status = AvailabilityStatus.partial);
                   Haptics.selection();
                 },
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.md,
-                    vertical: AppSpacing.xs,
-                  ),
-                  child: Text(
-                    context.l10n.availabilityStatusPartial,
-                    style: AppTypography.label,
-                  ),
-                ),
               ),
             ],
           ),

--- a/test/features/availability/availability_page_test.dart
+++ b/test/features/availability/availability_page_test.dart
@@ -95,7 +95,7 @@ void main() {
     expect(find.byType(AppBar), findsOneWidget);
   });
 
-  testWidgets('day_bottom_sheet uses GlassButton for status selection', (tester) async {
+  testWidgets('day_bottom_sheet uses GlassChip for status selection', (tester) async {
     // Arrange
     await tester.pumpWidget(
       MaterialApp(
@@ -122,7 +122,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Assert
-    expect(find.byType(GlassButton), findsNWidgets(3));
+    expect(find.byType(GlassChip), findsNWidgets(3));
     expect(find.byKey(const Key('status_free')), findsOneWidget);
     expect(find.byKey(const Key('status_busy')), findsOneWidget);
     expect(find.byKey(const Key('status_partial')), findsOneWidget);
@@ -156,11 +156,11 @@ void main() {
 
     // Assert initial state
     expect(
-      tester.widget<GlassButton>(find.byKey(const Key('status_free'))).selected,
+      tester.widget<GlassChip>(find.byKey(const Key('status_free'))).selected,
       isTrue,
     );
     expect(
-      tester.widget<GlassButton>(find.byKey(const Key('status_busy'))).selected,
+      tester.widget<GlassChip>(find.byKey(const Key('status_busy'))).selected,
       isFalse,
     );
 
@@ -170,11 +170,11 @@ void main() {
 
     // Assert updated state
     expect(
-      tester.widget<GlassButton>(find.byKey(const Key('status_busy'))).selected,
+      tester.widget<GlassChip>(find.byKey(const Key('status_busy'))).selected,
       isTrue,
     );
     expect(
-      tester.widget<GlassButton>(find.byKey(const Key('status_free'))).selected,
+      tester.widget<GlassChip>(find.byKey(const Key('status_free'))).selected,
       isFalse,
     );
   });


### PR DESCRIPTION
## Summary
- replace GlassButton widgets with GlassChip in day bottom sheet
- update availability tests to look for GlassChip and check selected state

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e9bc9348832087ab1d99fa2dfa89