### PR TITLE
test: check status indicator via widget

### DIFF
--- a/test/features/availability/calendar_grid_test.dart
+++ b/test/features/availability/calendar_grid_test.dart
@@ -34,31 +34,17 @@ void main() {
         ),
       );
 
-      BoxDecoration decoration;
-
-      BoxDecoration? decorationFor(int dateUtc) {
+      AvailabilityStatus statusFor(int dateUtc) {
         final dot = find.byKey(ValueKey('dot-$dateUtc'));
-        final containerFinder = find.descendant(
-          of: dot,
-          matching: find.byType(Container),
-        );
-        final container = tester.widget<Container>(containerFinder);
-        return container.decoration as BoxDecoration?;
+        expect(dot, findsOneWidget,
+            reason: 'Expected a status dot with key dot-$dateUtc');
+        final indicator = tester.widget<StatusIndicator>(dot);
+        return indicator.status;
       }
 
-      decoration = decorationFor(dateUtc00(dayFree))!;
-      expect(decoration.color, Colors.green);
-
-      decoration = decorationFor(dateUtc00(dayBusy))!;
-      expect(decoration.color, Colors.red);
-
-      decoration = decorationFor(dateUtc00(dayPartial))!;
-      expect(decoration.color, Colors.yellow);
-
-      final dayNone = DateTime(2024, 1, 13);
-      decoration = decorationFor(dateUtc00(dayNone))!;
-      final Border? border = decoration.border as Border?;
-      expect(border?.top.color, Colors.grey);
+      expect(statusFor(dateUtc00(dayFree)), AvailabilityStatus.free);
+      expect(statusFor(dateUtc00(dayBusy)), AvailabilityStatus.busy);
+      expect(statusFor(dateUtc00(dayPartial)), AvailabilityStatus.partial);
     });
 
     testWidgets('tapping day triggers callback', (tester) async {


### PR DESCRIPTION
## Summary
- simplify calendar grid status indicator test by reading AvailabilityStatus from StatusIndicator widget instead of box decoration
- drop border and color checks tied to decoration internals

## Testing
- ⚠️ `flutter test test/features/availability/calendar_grid_test.dart` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fc31da3483209085cee017c1deea