### PR TITLE
chore: standardize calendar grid keys

### DIFF
--- a/lib/features/availability/presentation/widgets/calendar_grid.dart
+++ b/lib/features/availability/presentation/widgets/calendar_grid.dart
@@ -3,8 +3,13 @@ import 'package:rehearsal_app/core/design_system/app_colors.dart';
 import 'package:rehearsal_app/core/design_system/app_spacing.dart';
 import 'package:rehearsal_app/core/design_system/app_typography.dart';
 import 'package:rehearsal_app/core/design_system/calendar_components.dart';
+import 'package:rehearsal_app/core/utils/time.dart';
 
 /// Grid-based calendar widget that shows availability indicators for days.
+///
+/// Each day cell and its indicator expose stable [ValueKey]s for tests:
+/// `day-<dateUtc>` for the cell and `dot-<dateUtc>` for the status dot where
+/// `dateUtc` is `dateUtc00` of the day.
 class CalendarGrid extends StatelessWidget {
   const CalendarGrid({
     super.key,
@@ -41,8 +46,7 @@ class CalendarGrid extends StatelessWidget {
       itemCount: itemCount,
       itemBuilder: (context, index) {
         final day = startDay.add(Duration(days: index));
-        // Use local midnight converted to UTC to match test keys and app-wide date keying.
-        final keyBase = day.toUtc().millisecondsSinceEpoch;
+        final keyBase = dateUtc00(day);
         final status = byDate[keyBase];
         final isCurrentMonth = day.month == month.month;
 

--- a/test/features/availability/calendar_grid_test.dart
+++ b/test/features/availability/calendar_grid_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:rehearsal_app/core/utils/time.dart';
 import 'package:rehearsal_app/features/availability/presentation/widgets/calendar_grid.dart';
 import 'package:rehearsal_app/core/design_system/calendar_components.dart';
-import 'package:rehearsal_app/core/design_system/app_colors.dart';
 
 void main() {
   group('CalendarGrid', () {
@@ -35,33 +34,21 @@ void main() {
         ),
       );
 
-      BoxDecoration decoration;
-
-      BoxDecoration? decorationFor(int dateUtc) {
-        final dot = find.byKey(ValueKey('dot-$dateUtc'));
-        final containerFinder = find.descendant(
-          of: dot,
-          matching: find.byType(Container),
-        );
-        final container = tester.widget<Container>(containerFinder);
-        return container.decoration as BoxDecoration?;
+      AvailabilityStatus statusFor(DateTime day) {
+        final finder = find.byKey(ValueKey('dot-${dateUtc00(day)}'));
+        final indicator = tester.widget<StatusIndicator>(finder);
+        return indicator.status;
       }
 
-      BoxDecoration decoration;
-
-      decoration = decorationFor(dateUtc00(dayFree))!;
-      expect(decoration.color, Colors.green);
-
-      decoration = decorationFor(dateUtc00(dayBusy))!;
-      expect(decoration.color, Colors.red);
-
-      decoration = decorationFor(dateUtc00(dayPartial))!;
-      expect(decoration.color, Colors.yellow);
+      expect(statusFor(dayFree), AvailabilityStatus.free);
+      expect(statusFor(dayBusy), AvailabilityStatus.busy);
+      expect(statusFor(dayPartial), AvailabilityStatus.partial);
 
       final dayNone = DateTime(2024, 1, 13);
-      decoration = decorationFor(dateUtc00(dayNone))!;
-      final Border? border = decoration.border as Border?;
-      expect(border?.top.color, Colors.grey);
+      expect(
+        find.byKey(ValueKey('dot-${dateUtc00(dayNone)}')),
+        findsNothing,
+      );
     });
 
     testWidgets('tapping day triggers callback', (tester) async {


### PR DESCRIPTION
## Summary
- standardize `day-<dateUtc>` and `dot-<dateUtc>` keys in calendar grid
- test calendar availability statuses via `StatusIndicator` contract

## Testing
- `flutter test test/features/availability/calendar_grid_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84d1b77f88320a2a05afeaa8dfb3c