### PR TITLE
feat: add app shell with bottom navigation

### DIFF
--- a/lib/core/navigation/app_shell.dart
+++ b/lib/core/navigation/app_shell.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rehearsal_app/core/design_system/haptics.dart';
+import 'package:rehearsal_app/features/dashboard/presentation/dashboard_page.dart';
+import 'package:rehearsal_app/features/calendar/presentation/calendar_page.dart';
+import 'package:rehearsal_app/features/availability/presentation/availability_page.dart';
+import 'package:rehearsal_app/features/projects/presentation/projects_page.dart';
+import 'package:rehearsal_app/l10n/app.dart';
+
+// Провайдер для текущего индекса навигации
+final navigationIndexProvider = StateProvider<int>((ref) => 0);
+
+class AppShell extends ConsumerWidget {
+  const AppShell({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentIndex = ref.watch(navigationIndexProvider);
+    
+    return Scaffold(
+      body: IndexedStack(
+        index: currentIndex,
+        children: const [
+          DashboardPage(),
+          CalendarPage(),
+          AvailabilityPage(),
+          ProjectsPage(),
+        ],
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: currentIndex,
+        onDestinationSelected: (index) {
+          ref.read(navigationIndexProvider.notifier).state = index;
+          Haptics.selection();
+        },
+        destinations: [
+          NavigationDestination(
+            icon: const Icon(Icons.dashboard_outlined),
+            selectedIcon: const Icon(Icons.dashboard),
+            label: context.l10n.navDashboard,
+          ),
+          NavigationDestination(
+            icon: const Icon(Icons.calendar_today_outlined),
+            selectedIcon: const Icon(Icons.calendar_today),
+            label: context.l10n.navCalendar,
+          ),
+          NavigationDestination(
+            icon: const Icon(Icons.access_time_outlined),
+            selectedIcon: const Icon(Icons.access_time_filled),
+            label: context.l10n.navAvailability,
+          ),
+          NavigationDestination(
+            icon: const Icon(Icons.folder_outlined),
+            selectedIcon: const Icon(Icons.folder),
+            label: context.l10n.navProjects,
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/projects/presentation/projects_page.dart
+++ b/lib/features/projects/presentation/projects_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class ProjectsPage extends StatelessWidget {
+  const ProjectsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Projects Page'),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -21,5 +21,9 @@
   "daySheetAvailabilityNone": "Availability: none",
   "daySheetRehearsals0": "Rehearsals: 0",
   "daySheetChangeAvailability": "Change availability",
-  "daySheetNewRehearsal": "New rehearsal"
+  "daySheetNewRehearsal": "New rehearsal",
+  "navDashboard": "Dashboard",
+  "navCalendar": "Calendar",
+  "navAvailability": "Availability",
+  "navProjects": "Projects"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -232,6 +232,31 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'New rehearsal'**
   String get daySheetNewRehearsal;
+
+  /// No description provided for @navDashboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Dashboard'**
+  String get navDashboard;
+
+  /// No description provided for @navCalendar.
+  ///
+  /// In en, this message translates to:
+  /// **'Calendar'**
+  String get navCalendar;
+
+  /// No description provided for @navAvailability.
+  ///
+  /// In en, this message translates to:
+  /// **'Availability'**
+  String get navAvailability;
+
+  /// No description provided for @navProjects.
+  ///
+  /// In en, this message translates to:
+  /// **'Projects'**
+  String get navProjects;
+
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -76,4 +76,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get daySheetNewRehearsal => 'New rehearsal';
+
+
+  @override
+  String get navDashboard => 'Dashboard';
+
+  @override
+  String get navCalendar => 'Calendar';
+
+  @override
+  String get navAvailability => 'Availability';
+
+  @override
+  String get navProjects => 'Projects';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -76,4 +76,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get daySheetNewRehearsal => 'Новая репетиция';
+
+
+  @override
+  String get navDashboard => 'Панель';
+
+  @override
+  String get navCalendar => 'Календарь';
+
+  @override
+  String get navAvailability => 'Доступность';
+
+  @override
+  String get navProjects => 'Проекты';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -21,5 +21,9 @@
   "daySheetAvailabilityNone": "Доступность: нет",
   "daySheetRehearsals0": "Репетиции: 0",
   "daySheetChangeAvailability": "Изменить доступность",
-  "daySheetNewRehearsal": "Новая репетиция"
+  "daySheetNewRehearsal": "Новая репетиция",
+  "navDashboard": "Панель",
+  "navCalendar": "Календарь",
+  "navAvailability": "Доступность",
+  "navProjects": "Проекты"
 }


### PR DESCRIPTION
## Summary
- add AppShell that hosts dashboard, calendar, availability and projects pages with bottom navigation
- localize navigation labels in English and Russian
- stub Projects page for navigation placeholder

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `dart format lib/core/navigation/app_shell.dart lib/features/projects/presentation/projects_page.dart lib/l10n/app_en.arb lib/l10n/app_ru.arb lib/l10n/app_localizations.dart lib/l10n/app_localizations_en.dart lib/l10n/app_localizations_ru.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9344bba288320884d18b48a9561f7