### PR TITLE
feat: add projects page stub

### DIFF
--- a/lib/features/projects/presentation/projects_page.dart
+++ b/lib/features/projects/presentation/projects_page.dart
@@ -1,13 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:rehearsal_app/l10n/app.dart';
 
 class ProjectsPage extends StatelessWidget {
   const ProjectsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n.navProjects),
+      ),
       body: Center(
-        child: Text('Projects Page'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.folder_outlined,
+              size: 64,
+              color: Colors.grey,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              context.l10n.noProjectsTitle,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              context.l10n.noProjectsDescription,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -25,5 +25,7 @@
   "navDashboard": "Dashboard",
   "navCalendar": "Calendar",
   "navAvailability": "Availability",
-  "navProjects": "Projects"
+  "navProjects": "Projects",
+  "noProjectsTitle": "No projects yet",
+  "noProjectsDescription": "You don't have any projects yet."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -257,6 +257,18 @@ abstract class AppLocalizations {
   /// **'Projects'**
   String get navProjects;
 
+  /// No description provided for @noProjectsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No projects yet'**
+  String get noProjectsTitle;
+
+  /// No description provided for @noProjectsDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'You don't have any projects yet.'**
+  String get noProjectsDescription;
+
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -89,4 +89,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get navProjects => 'Projects';
+
+  @override
+  String get noProjectsTitle => 'No projects yet';
+
+  @override
+  String get noProjectsDescription => 'You don\'t have any projects yet.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -89,4 +89,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get navProjects => 'Проекты';
+
+  @override
+  String get noProjectsTitle => 'Проектов пока нет';
+
+  @override
+  String get noProjectsDescription => 'У вас ещё нет проектов.';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -25,5 +25,7 @@
   "navDashboard": "Панель",
   "navCalendar": "Календарь",
   "navAvailability": "Доступность",
-  "navProjects": "Проекты"
+  "navProjects": "Проекты",
+  "noProjectsTitle": "Проектов пока нет",
+  "noProjectsDescription": "У вас ещё нет проектов."
 }


### PR DESCRIPTION
## Summary
- add ProjectsPage placeholder with localized empty-state content
- add English and Russian localization strings for projects page

## Testing
- `dart format lib/features/projects/presentation/projects_page.dart lib/l10n/app_localizations.dart lib/l10n/app_localizations_en.dart lib/l10n/app_localizations_ru.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9383d3aec832082a52590924f0c12