### PR TITLE
feat: add error state widget

### DIFF
--- a/lib/core/design_system/app_typography.dart
+++ b/lib/core/design_system/app_typography.dart
@@ -32,6 +32,8 @@ final class AppTypography {
     height: 1.2,
   );
 
+  static const TextStyle headingMedium = displaySmall;
+
   // === Заголовки поменьше ===
   static const TextStyle titleSm = TextStyle(
     fontFamily: _fontFamily,

--- a/lib/core/widgets/error_state.dart
+++ b/lib/core/widgets/error_state.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:rehearsal_app/core/design_system/app_colors.dart';
+import 'package:rehearsal_app/core/design_system/app_spacing.dart';
+import 'package:rehearsal_app/core/design_system/app_typography.dart';
+
+class ErrorState extends StatelessWidget {
+  const ErrorState({
+    super.key,
+    required this.error,
+    this.onRetry,
+  });
+
+  final String error;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: AppSpacing.paddingXL,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: 64,
+              color: AppColors.statusBusy,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            Text(
+              'Something went wrong',
+              style: AppTypography.headingMedium,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              error,
+              style: AppTypography.bodyMedium.copyWith(
+                color: AppColors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: AppSpacing.xl),
+              ElevatedButton(
+                onPressed: onRetry,
+                child: const Text('Try again'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable ErrorState widget to show errors and optional retry button
- expose headingMedium text style in design system as alias to displaySmall

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93d08a54c83208a9f8ee51d8be9bd