### PR TITLE
Add responsive layout utility

### DIFF
--- a/lib/core/utils/responsive.dart
+++ b/lib/core/utils/responsive.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class Responsive extends StatelessWidget {
+  final Widget mobile;
+  final Widget? tablet;
+  final Widget? desktop;
+
+  const Responsive({
+    super.key,
+    required this.mobile,
+    this.tablet,
+    this.desktop,
+  });
+
+  // Breakpoints
+  static const double mobileBreakpoint = 600;
+  static const double tabletBreakpoint = 1200;
+
+  static bool isMobile(BuildContext context) =>
+      MediaQuery.of(context).size.width < mobileBreakpoint;
+
+  static bool isTablet(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    return width >= mobileBreakpoint && width < tabletBreakpoint;
+  }
+
+  static bool isDesktop(BuildContext context) =>
+      MediaQuery.of(context).size.width >= tabletBreakpoint;
+
+  static T value<T>(
+    BuildContext context, {
+    required T mobile,
+    T? tablet,
+    T? desktop,
+  }) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= tabletBreakpoint && desktop != null) return desktop;
+    if (width >= mobileBreakpoint && tablet != null) return tablet;
+    return mobile;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= tabletBreakpoint && desktop != null) {
+          return desktop!;
+        }
+        if (constraints.maxWidth >= mobileBreakpoint && tablet != null) {
+          return tablet!;
+        }
+        return mobile;
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add Responsive widget with mobile, tablet, and desktop breakpoints
- expose helper methods to query device type or responsive value

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93f50663c8320b031d3f54dbe0b8f