### PR TITLE
feat: add dashboard header widget

### DIFF
--- a/lib/features/dashboard/widgets/dashboard_header.dart
+++ b/lib/features/dashboard/widgets/dashboard_header.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rehearsal_app/core/design_system/app_typography.dart';
+import 'package:rehearsal_app/core/design_system/app_spacing.dart';
+import 'package:rehearsal_app/core/design_system/app_colors.dart';
+
+class DashboardHeader extends ConsumerWidget {
+  const DashboardHeader({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final hour = DateTime.now().hour;
+    final greeting = hour < 12
+        ? 'Good morning'
+        : hour < 18
+            ? 'Good afternoon'
+            : 'Good evening';
+
+    return Padding(
+      padding: AppSpacing.paddingLG,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            greeting,
+            style: AppTypography.displayMedium,
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'Ready for rehearsal?',
+            style: AppTypography.bodyLarge.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `DashboardHeader` widget with time-based greeting and rehearsal prompt

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9425365f48320aa842dce6e216d7a