### PR TITLE
feat: add quick actions widget

### DIFF
--- a/lib/features/dashboard/widgets/quick_actions.dart
+++ b/lib/features/dashboard/widgets/quick_actions.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rehearsal_app/core/design_system/glass_system.dart';
+import 'package:rehearsal_app/core/design_system/app_spacing.dart';
+import 'package:rehearsal_app/core/design_system/app_typography.dart';
+import 'package:rehearsal_app/core/design_system/haptics.dart';
+import 'package:rehearsal_app/core/navigation/app_shell.dart';
+
+class QuickActions extends ConsumerWidget {
+  const QuickActions({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Quick Actions',
+            style: AppTypography.headingMedium,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Row(
+            children: [
+              Expanded(
+                child: _ActionButton(
+                  icon: Icons.add_circle_outline,
+                  label: 'New Rehearsal',
+                  onTap: () {
+                    Haptics.light();
+                    // TODO: Open create rehearsal dialog
+                  },
+                ),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: _ActionButton(
+                  icon: Icons.access_time,
+                  label: 'Set Availability',
+                  onTap: () {
+                    Haptics.light();
+                    ref.read(navigationIndexProvider.notifier).state = 2;
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassButton(
+      onTap: onTap,
+      child: Padding(
+        padding: AppSpacing.paddingMD,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 32),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              label,
+              style: AppTypography.labelMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add QuickActions widget with buttons for creating rehearsals and setting availability

## Testing
- `flutter format lib/features/dashboard/widgets/quick_actions.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b94762e5ac8320a4fab1fda6078416