### PR TITLE
feat: build full dashboard layout

### DIFF
--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 
 import 'package:rehearsal_app/core/design_system/app_spacing.dart';
-import 'package:rehearsal_app/core/design_system/glass_system.dart' as ds;
 import 'package:rehearsal_app/features/dashboard/widgets/day_scroller.dart';
+import 'package:rehearsal_app/features/dashboard/widgets/dashboard_header.dart';
+import 'package:rehearsal_app/features/dashboard/widgets/upcoming_rehearsals.dart';
+import 'package:rehearsal_app/features/dashboard/widgets/project_availability.dart';
+import 'package:rehearsal_app/features/dashboard/widgets/quick_actions.dart';
+import 'package:rehearsal_app/features/dashboard/widgets/dash_background.dart';
 
 class DashboardPage extends StatefulWidget {
   const DashboardPage({super.key});
@@ -12,29 +16,75 @@ class DashboardPage extends StatefulWidget {
 }
 
 class _DashboardPageState extends State<DashboardPage> {
+  DateTime _selectedDate = DateTime.now();
+
+  void _handleDateChanged(DateTime date) {
+    setState(() {
+      _selectedDate = date;
+    });
+    // TODO: Load data for selected date
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: ds.GlassBackground(
+      body: DashBackground(
         child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.lg,
-              vertical: AppSpacing.md,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Стеклянная панель с DayScroller — БЕЗ дополнительных обёрток стекла внутри
-                ds.GlassPanel(
-                  child: SizedBox(height: 120, child: DayScroller()),
+          child: CustomScrollView(
+            slivers: [
+              // Header with greeting
+              const SliverToBoxAdapter(
+                child: DashboardHeader(),
+              ),
+
+              // Day scroller
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.lg,
+                    vertical: AppSpacing.md,
+                  ),
+                  child: SizedBox(
+                    height: 120,
+                    child: DayScroller(
+                      initialDate: _selectedDate,
+                      onDateChanged: _handleDateChanged,
+                    ),
+                  ),
                 ),
-                const SizedBox(height: AppSpacing.lg),
-              ],
-            ),
+              ),
+
+              // Upcoming rehearsals
+              const SliverToBoxAdapter(
+                child: UpcomingRehearsals(),
+              ),
+
+              const SliverToBoxAdapter(
+                child: SizedBox(height: AppSpacing.lg),
+              ),
+
+              // Project availability
+              const SliverToBoxAdapter(
+                child: ProjectAvailability(),
+              ),
+
+              const SliverToBoxAdapter(
+                child: SizedBox(height: AppSpacing.lg),
+              ),
+
+              // Quick actions
+              const SliverToBoxAdapter(
+                child: QuickActions(),
+              ),
+
+              const SliverToBoxAdapter(
+                child: SizedBox(height: AppSpacing.xl),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 }
+

--- a/lib/features/dashboard/widgets/dash_background.dart
+++ b/lib/features/dashboard/widgets/dash_background.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:rehearsal_app/core/design_system/glass_system.dart' as ds;
+
+/// Dashboard-specific background using the app's glass design system.
+class DashBackground extends StatelessWidget {
+  const DashBackground({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ds.GlassBackground(child: child);
+  }
+}
+


### PR DESCRIPTION
## Summary
- expand dashboard to include header, day scroller, upcoming rehearsals, availability, and quick actions
- add dedicated dashboard background widget

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b948802388832088b97fcb59e0cce3