### PR TITLE
feat: add animated switcher wrapper

### DIFF
--- a/lib/core/widgets/animated_switcher_wrapper.dart
+++ b/lib/core/widgets/animated_switcher_wrapper.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class AnimatedSwitcherWrapper extends StatelessWidget {
+  const AnimatedSwitcherWrapper({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 300),
+  });
+
+  final Widget child;
+  final Duration duration;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: duration,
+      transitionBuilder: (child, animation) {
+        return FadeTransition(
+          opacity: animation,
+          child: SlideTransition(
+            position: animation.drive(
+              Tween(begin: const Offset(0, 0.1), end: Offset.zero),
+            ),
+            child: child,
+          ),
+        );
+      },
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `AnimatedSwitcherWrapper` widget to provide fade and slide transitions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9541eca4c8320861ebfe685670602